### PR TITLE
MacOS port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,8 @@ host_disk_kb := $(shell sh etc/host-disk-kb.sh $(host))
 # The -finline-math option tells the cross compiler to use the CSP math opcodes,
 # rather than calling the TRANSCEN intrinsic unit.
 #
-XCFLAGS = --arch=$(arch) -Wno-shadow
+#XCFLAGS = --arch=$(arch) -Wno-shadow
+XCFLAGS = -Wno-shadow
 
 #
 # The Cross Assembler Flags


### PR DESCRIPTION
First draft with libexplain removed from VM, XC and FS repositories. `--arch=` removed here.

To create working UCSD Pascal system on macOS:
```
Run `./configure; make` on each of the other three projects (vm, xc and fs).
Here, run:
$ make
$ mkdir bin
$ cp -p ../*vm/bin/* ../*xc/bin/* ../*fs/bin/* bin (copy all binaries from other three projects)
$ export PATH=`pwd`/bin:$PATH
$ ucsdpsys_vm -f stage1/klebsch/system.vol
```
